### PR TITLE
Fix helm chart index building

### DIFF
--- a/vars/buildHelmChart.groovy
+++ b/vars/buildHelmChart.groovy
@@ -79,6 +79,7 @@ def call(body) {
                 sh """
                   mkdir -p ${name}
                   mv ../${name}*.tgz ${name}
+                  helm repo index ./
                   mkdir /tmp/helm-repo-html
                   wget -O - https://github.com/halkeye/helm-repo-html/releases/download/v0.0.8/helm-repo-html_0.0.8_linux_x86_64.tar.gz | tar xzf - -C /tmp/helm-repo-html
                   /tmp/helm-repo-html/bin/helm-repo-html


### PR DESCRIPTION
Between https://github.com/halkeye/helm-charts/commit/46ae6a88ba31382e19a3308cf5bfb8ccb60499b1 and https://github.com/halkeye/helm-charts/commit/53ba2803757c312d1c3a6b4a55cd8e2d06904751, Jenkins stopped updating index.yaml and index.html in halkeye/helm-charts.

The `helm repo index` command was dropped inadvertently in https://github.com/halkeye/jenkins-shared-library/commit/1ed180978b02338be92fd9af08c0cedfa7a9e1bc.